### PR TITLE
Add console command to delete synced Mailchimp product by ID

### DIFF
--- a/src/console/controllers/UtilsController.php
+++ b/src/console/controllers/UtilsController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ether\mc\console\controllers;
+
+use yii\console\Controller;
+use yii\console\ExitCode;
+use yii\helpers\Console;
+use ether\mc\MailchimpCommerce;
+
+class UtilsController extends Controller
+{
+    public function actionDeleteMailchimpProduct($productId)
+    {
+        if ($productId != (int)$productId || $productId <= 0) {
+            $this->stdout('Missing or invalid product ID', Console::FG_RED);
+            $this->stdout(PHP_EOL);
+            return ExitCode::USAGE;
+        }
+
+        if (!MailchimpCommerce::getInstance()->products->deleteProductById($productId)) {
+            $this->stdout('Unable to delete product ID ' . $productId, Console::FG_RED);
+            $this->stdout(PHP_EOL);
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        $this->stdout('Successfully deleted product ID ' . $productId . ' from Mailchimp', Console::FG_GREEN);
+        $this->stdout(PHP_EOL);
+        return ExitCode::OK;
+    }
+}


### PR DESCRIPTION
Moving the changes made in https://github.com/FosterCommerce/FTI/pull/364 to the plugin. The console command is now:

```
./craft mailchimp-commerce/utils/delete-mailchimp-product <product-id>
```